### PR TITLE
Comment "hub.imageTag" in values for consistency

### DIFF
--- a/chart/selenium-grid/values.yaml
+++ b/chart/selenium-grid/values.yaml
@@ -153,7 +153,7 @@ hub:
   # Selenium Hub image name
   imageName: selenium/hub
   # Selenium Hub image tag (this overwrites global.seleniumGrid.imageTag parameter)
-  imageTag: 4.0.0-beta-1-prerelease-20210114
+  # imageTag: 4.0.0-beta-1-prerelease-20210114
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
   # Custom annotations for Selenium Hub pod


### PR DESCRIPTION
Hey @pedrodotmc,
A small change to keep consistent behaviour when overriding the `global.seleniumGrid.imageTag` value.

I have commented out the hub image tag so by default it will inherit `global.seleniumGrid.imageTag` but if the user specifys `hub.imageTag` then that will take precedence.


